### PR TITLE
Update checkbox state when 'checked' props change

### DIFF
--- a/src/checkbox.jsx
+++ b/src/checkbox.jsx
@@ -169,6 +169,12 @@ let Checkbox = React.createClass({
   _handleStateChange(newSwitched) {
     this.setState({switched: newSwitched});
   },
+  
+  componentWillReceiveProps(nextProps) {
+    if (nextProps.checked !== this.state.switched) {
+      this.setState({switched: nextProps.checked});
+    }
+  },
 
 });
 


### PR DESCRIPTION
To enable us to control the checkbox's state from its owner. 

This is helpful when having checkboxes that cannot be mutually active, a good example is a Male/Female checkbox situation.

``` html
<Checkbox label="Male" checked={this.state.gender === "male"} />
<Checkbox label="Female" checked={this.state.gender === "female"} />
```
